### PR TITLE
make ErrTooManySPFRecords exported.

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -1210,7 +1210,7 @@ func TestSelectingRecord(t *testing.T) {
 		{"v-spf2", None, ErrSPFNotFound},
 		{"v-spf10", None, ErrSPFNotFound},
 		{"no-record", None, ErrSPFNotFound},
-		{"many-records", Permerror, errTooManySPFRecords},
+		{"many-records", Permerror, ErrTooManySPFRecords},
 		{"mixed-records", Pass, nil},
 	}
 

--- a/spf.go
+++ b/spf.go
@@ -15,7 +15,7 @@ var (
 	ErrDNSLimitExceeded  = errors.New("limit exceeded")
 	ErrSPFNotFound       = errors.New("SPF record not found")
 	errInvalidCIDRLength = errors.New("invalid CIDR length")
-	errTooManySPFRecords = errors.New("too many SPF records")
+	ErrTooManySPFRecords = errors.New("too many SPF records")
 )
 
 // IPMatcherFunc returns true if ip matches to implemented rules.
@@ -202,7 +202,7 @@ func filterSPF(txt []string) (string, error) {
 		n++
 	}
 	if n > 1 {
-		return "", errTooManySPFRecords
+		return "", ErrTooManySPFRecords
 	}
 	return spf, nil
 }


### PR DESCRIPTION
The error is useful outside the library, and this way it's easier to be checked for.